### PR TITLE
feature/sync-title-field

### DIFF
--- a/angular/projects/admin/src/app/admin/content-entry/content-entry-form/content-entry-form.component.html
+++ b/angular/projects/admin/src/app/admin/content-entry/content-entry-form/content-entry-form.component.html
@@ -9,29 +9,6 @@
           </mat-card-title>
         </mat-card-header>
         <mat-card-content>
-
-
-          <div class="row">
-            <div class="col">
-              <mat-form-field class="full-width">
-                <input matInput
-                       placeholder="Title"
-                       formControlName="title"
-                       (input)="onTitleChange($event.target.value)">
-                <mat-error *ngIf="entryForm.controls['urlPath'].hasError('required')">
-                  Title is <strong>required</strong>
-                </mat-error>
-              </mat-form-field>
-            </div>
-          </div>
-        </mat-card-content>
-
-        <mat-card-header>
-          <mat-card-title>
-            {{ (documentType$ | async)?.title }} content
-          </mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
           <div formGroupName="dataForm">
             <div class="row"
                  *ngFor="let field of (documentType$ | async)?.fields">
@@ -44,6 +21,7 @@
                   <!-- If input type is just simple line of text -->
                   <input matInput
                          *ngSwitchCase="'input-text'"
+                         (input)="onTitleChange($event.target.value, field.isTitle)"
                          placeholder="{{field.title}}"
                          formControlName="{{field.key}}">
 

--- a/angular/projects/admin/src/app/admin/content-entry/content-entry-form/content-entry-form.component.ts
+++ b/angular/projects/admin/src/app/admin/content-entry/content-entry-form/content-entry-form.component.ts
@@ -89,10 +89,13 @@ export class ContentEntryFormComponent implements OnInit, OnDestroy {
     }
   }
 
-  onTitleChange(title: string) {
-    if (!this.publishedTime) {
+  onTitleChange(title: string, isTitle: boolean) {
+    if (!this.publishedTime && isTitle) {
       // Only auto slugify title if document has't been published before
       this.entryForm.controls['urlPath'].setValue(this._slugify(title));
+      this.entryForm.controls['title'].setValue(title);
+    } else if (isTitle) {
+      this.entryForm.controls['title'].setValue(title);
     }
   }
 


### PR DESCRIPTION
Removing the HTML input field for title in edit entry. For each document-type document on field property has an attribute isTitle. That means that will copy every change to the blog.data.title to blog.title, because every document must have a title. So every document type must declare 1 data field that will function as a title