### PR TITLE
Issue/45-unifying-styling-page-header-breadcrumbs

### DIFF
--- a/angular/projects/admin/src/app/admin/components/breadcrumb/breadcrumb.component.html
+++ b/angular/projects/admin/src/app/admin/components/breadcrumb/breadcrumb.component.html
@@ -1,7 +1,6 @@
-<a mat-list-item
-   class="breadcrumb"
-   routerLink="{{routerLink}}"
-   routerLinkActive="router-link-active">
+<span class="breadcrumb"
+      routerLink="{{routerLink}}"
+      routerLinkActive="router-link-active">
   <ng-content></ng-content>
-  <mat-icon matListIcon>chevron_right</mat-icon>
-</a>
+  <mat-icon class="icon">chevron_right</mat-icon>
+</span>

--- a/angular/projects/admin/src/app/admin/components/breadcrumb/breadcrumb.component.scss
+++ b/angular/projects/admin/src/app/admin/components/breadcrumb/breadcrumb.component.scss
@@ -1,3 +1,14 @@
 .breadcrumb {
-  display: table-cell;
+  font-size: 0.8em;
+  cursor: pointer;
+}
+
+.breadcrumb:focus {
+  outline: none;
+}
+
+.breadcrumb .icon {
+  position: relative;
+  top: 3px;
+  font-size: 1em;
 }

--- a/angular/projects/admin/src/app/admin/components/breadcrumbs/breadcrumbs.component.html
+++ b/angular/projects/admin/src/app/admin/components/breadcrumbs/breadcrumbs.component.html
@@ -1,7 +1,5 @@
 <div class="button-row">
   <ng-container *cdkPortal>
-    <mat-nav-list class="breadcrumbs">
       <ng-content></ng-content>
-    </mat-nav-list>
   </ng-container>
 </div>

--- a/angular/projects/admin/src/app/admin/components/page-title/page-title.component.html
+++ b/angular/projects/admin/src/app/admin/components/page-title/page-title.component.html
@@ -1,3 +1,5 @@
 <ng-container *cdkPortal>
-  <h1> {{ pageTitle }}</h1>
+  <span class="page-title">
+    {{ pageTitle }}
+  </span>
 </ng-container>

--- a/angular/projects/admin/src/app/admin/components/page-title/page-title.component.scss
+++ b/angular/projects/admin/src/app/admin/components/page-title/page-title.component.scss
@@ -1,0 +1,3 @@
+.page-title {
+  font-size: 0.8em;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18025983/53316997-e3710c80-3904-11e9-9488-882117dd71be.png)

![image](https://user-images.githubusercontent.com/18025983/53317147-7f9b1380-3905-11e9-849f-6e1fe48c173f.png)


I replace mat-nav-list tag because for styling  it padding must change form the mat-nav-list-content class that must be using ng-deep from css. So I use span and some styling to make it better instead