### PR TITLE
Feature/52 convert webp images

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tanam",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -961,6 +961,16 @@
         "supports-color": "^5.3.0"
       }
     },
+    "child-process-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
+      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
+      "requires": {
+        "cross-spawn": "^4.0.2",
+        "node-version": "^1.0.0",
+        "promise-polyfill": "^6.0.1"
+      }
+    },
     "chokidar": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.2.tgz",
@@ -1230,6 +1240,31 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "crypto-js": {
@@ -3712,8 +3747,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -4167,7 +4201,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -4175,9 +4208,16 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
+      }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "requires": {
+        "mkdirp": "*"
       }
     },
     "modelo": {
@@ -4229,6 +4269,11 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
       "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+    },
+    "node-version": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
+      "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ=="
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -4410,6 +4455,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "promise-polyfill": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
     },
     "protobufjs": {
       "version": "6.8.8",
@@ -5600,7 +5650,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -37,11 +37,14 @@
     "build:dist": "npm run build:all && npm run package"
   },
   "dependencies": {
+    "child-process-promise": "^2.2.1",
     "crypto-js": "^3.1.9-1",
     "dustjs-helpers": "^1.7.4",
     "dustjs-linkedin": "^2.7.5",
     "firebase-admin": "^6.5.1",
-    "firebase-functions": "^2.1.0"
+    "firebase-functions": "^2.1.0",
+    "mkdirp": "^0.5.1",
+    "mkdirp-promise": "^5.0.1"
   },
   "devDependencies": {
     "@types/crypto-js": "^3.1.43",

--- a/functions/src/triggers/storage.ts
+++ b/functions/src/triggers/storage.ts
@@ -1,0 +1,32 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import * as mkdirp from 'mkdirp-promise';
+import { ObjectMetadata } from 'firebase-functions/lib/providers/storage';
+
+import { ImageData } from '../../../models/image-data.models';
+
+const spawn = require('child-process-promise').spawn;
+
+export const convertToWebP = functions.storage.object().onFinalize(async (object: ObjectMetadata) => {
+  const image = new ImageData(object);
+
+  if (!image.contentType.startsWith('image/')) return null;
+  if (image.baseFileName.endsWith('.webp')) return null;
+
+  const bucket = admin.storage().bucket(image.bucketName);
+
+  await mkdirp(image.tempLocalDir);
+  await bucket
+    .file(image.filePath)
+    .download({ destination: image.tempLocalFile });
+  console.log('The file has been downloaded to', image.tempLocalFile);
+
+  await spawn('convert', [image.tempLocalFile, image.tempLocalWebPFile]);
+  console.log('WebP image created at', image.tempLocalWebPFile);
+
+  await bucket.upload(image.tempLocalWebPFile, {
+    destination: image.imageFilePath,
+  });
+
+  return null;
+})

--- a/functions/src/triggers/storage.ts
+++ b/functions/src/triggers/storage.ts
@@ -23,7 +23,12 @@ export const convertToWebP = functions.storage.object().onFinalize(async (object
     .download({ destination: image.tempLocalFile });
   console.log('The file has been downloaded to', image.tempLocalFile);
 
-  await spawn('convert', [image.tempLocalFile, image.tempLocalWebPFile]);
+  await spawn('convert', [
+    image.tempLocalFile,
+    '-define',
+    'webp:lossless=true',
+    image.tempLocalWebPFile,
+  ]);
   console.log('WebP image created at', image.tempLocalWebPFile);
 
   await bucket.upload(image.tempLocalWebPFile, {

--- a/functions/src/triggers/storage.ts
+++ b/functions/src/triggers/storage.ts
@@ -7,6 +7,8 @@ import { ImageData } from '../../../models/image-data.models';
 
 const spawn = require('child-process-promise').spawn;
 
+const siteCollection = () => admin.firestore().collection('tanam').doc(process.env.GCLOUD_PROJECT);
+
 export const convertToWebP = functions.storage.object().onFinalize(async (object: ObjectMetadata) => {
   const image = new ImageData(object);
 
@@ -28,5 +30,13 @@ export const convertToWebP = functions.storage.object().onFinalize(async (object
     destination: image.imageFilePath,
   });
 
+  await updateVariantsImagesDocument(image.fileName);
+
   return null;
 })
+
+const updateVariantsImagesDocument = async (fileName) => {
+  const doc = await siteCollection()
+    .collection('files').doc(fileName);
+
+}

--- a/models/image-data.models.ts
+++ b/models/image-data.models.ts
@@ -1,0 +1,45 @@
+import * as path from 'path';
+import * as os from 'os';
+import { ObjectMetadata } from 'firebase-functions/lib/providers/storage';
+
+const WEBP_EXTENSION = '.webp';
+
+export class ImageData {
+  bucketName: string;
+  filePath: string;
+  baseFileName: string;
+  fileDir: string;
+  imageFilePath: string;
+  tempLocalFile: string;
+  tempLocalDir: string;
+  tempLocalJPEGFile: string;
+  contentType: string;
+  metadata: any;
+
+  constructor(inputImage: ObjectMetadata) {
+    this.bucketName = inputImage.bucket;
+    this.filePath = inputImage.name;
+    this.baseFileName = path.basename(
+      this.filePath,
+      path.extname(this.filePath),
+    );
+    this.fileDir = path.dirname(this.filePath);
+    this.imageFilePath = path.normalize(
+      path.format({
+        dir: this.fileDir,
+        name: this.baseFileName,
+        ext: WEBP_EXTENSION,
+      }),
+    );
+
+    this.tempLocalFile = path.join(os.tmpdir(), this.filePath);
+    this.tempLocalDir = path.dirname(this.tempLocalFile);
+    this.tempLocalJPEGFile = path.join(os.tmpdir(), this.imageFilePath);
+
+    this.contentType = inputImage.contentType;
+    this.metadata = {
+      contentType: this.contentType,
+      metadata: inputImage.metadata,
+    };
+  }
+}

--- a/models/image-data.models.ts
+++ b/models/image-data.models.ts
@@ -7,6 +7,7 @@ const WEBP_EXTENSION = '.webp';
 export class ImageData {
   bucketName: string;
   filePath: string;
+  fileName: string;
   baseFileName: string;
   fileDir: string;
   imageFilePath: string;
@@ -41,5 +42,8 @@ export class ImageData {
       contentType: this.contentType,
       metadata: inputImage.metadata,
     };
+
+    const [tanamDir, imageDir, fileName] = this.filePath.split('/');
+    this.fileName = fileName;
   }
 }

--- a/models/image-data.models.ts
+++ b/models/image-data.models.ts
@@ -12,7 +12,7 @@ export class ImageData {
   imageFilePath: string;
   tempLocalFile: string;
   tempLocalDir: string;
-  tempLocalJPEGFile: string;
+  tempLocalWebPFile: string;
   contentType: string;
   metadata: any;
 
@@ -34,7 +34,7 @@ export class ImageData {
 
     this.tempLocalFile = path.join(os.tmpdir(), this.filePath);
     this.tempLocalDir = path.dirname(this.tempLocalFile);
-    this.tempLocalJPEGFile = path.join(os.tmpdir(), this.imageFilePath);
+    this.tempLocalWebPFile = path.join(os.tmpdir(), this.imageFilePath);
 
     this.contentType = inputImage.contentType;
     this.metadata = {


### PR DESCRIPTION
Closes #52 

The first attempt waa using `imagemin` and this is the error I got.

<img width="893" alt="screen shot 2019-02-28 at 10 09 48 am" src="https://user-images.githubusercontent.com/8610935/53536385-291a1900-3b41-11e9-9707-f8d5b166a48d.png">

It seems that cloud functions does not have the `libjpeg` package on their system. But it is listed [here](https://cloud.google.com/functions/docs/reference/nodejs-system-packages) that the package does exists.

Second attempt is using the `imagemagick`, which is already built in inside the cloud functions. I've tried to do a basic conversion (from `png` to `jpg`) and it works fine. But to convert it to webP it doesn't seems to work. Details of the log is not really helpful also.

<img width="891" alt="screen shot 2019-02-28 at 10 16 26 am" src="https://user-images.githubusercontent.com/8610935/53536596-ed338380-3b41-11e9-9862-61dd99aef897.png">

