### PR TITLE
Fixing: New documents not saving properly

### DIFF
--- a/angular/projects/admin/src/app/admin/document/document-edit/document-edit.component.ts
+++ b/angular/projects/admin/src/app/admin/document/document-edit/document-edit.component.ts
@@ -176,11 +176,7 @@ export class DocumentEditComponent implements OnInit, OnDestroy {
   }
 
   private _onTitleChange(title: string) {
-    if (!title) {
-      return;
-    }
-
-    if (!this.documentForm.get('published').value) {
+    if (!!title && !this.documentForm.get('published').value) {
       // Only auto slugify title if document has't been published before
       this.documentForm.controls['url'].setValue(`${this._rootSlug}/${this._slugify(title)}`);
       this.documentForm.controls['title'].setValue(title);

--- a/angular/projects/admin/src/app/services/document.service.ts
+++ b/angular/projects/admin/src/app/services/document.service.ts
@@ -66,6 +66,7 @@ export class DocumentService {
     }
 
     document.url = DocumentService._normalizeUrl(document.url || '/');
+    document.published = document.published || null;
     document.updated = firebase.firestore.FieldValue.serverTimestamp();
     document.revision = firebase.firestore.FieldValue.increment(1);
 


### PR DESCRIPTION
Fixing issue #111. New documents didn't save properly because the `published` timestamp was `undefined` instead of `null`. This also affected the title of the document.