### PR TITLE
Building and using dependency graph for cache management

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,6 +5,20 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "dependencies",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "rendered",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "documentType",
           "order": "ASCENDING"
         },

--- a/functions/src/models/cache.models.ts
+++ b/functions/src/models/cache.models.ts
@@ -1,7 +1,0 @@
-export type CacheTaskAction = 'create' | 'update' | 'delete';
-
-export interface CacheTask {
-    action: CacheTaskAction;
-    domain: string;
-    url: string;
-}

--- a/functions/src/models/document.models.ts
+++ b/functions/src/models/document.models.ts
@@ -11,7 +11,6 @@ export interface Document {
     status: DocumentStatus;
     tags: string[];
     standalone: boolean;
-    timesRendered: number | any; // firebase.firestore.FieldValue.increment;
     rendered?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     published?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     updated: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;

--- a/functions/src/models/document.models.ts
+++ b/functions/src/models/document.models.ts
@@ -11,6 +11,7 @@ export interface Document {
     status: DocumentStatus;
     tags: string[];
     standalone: boolean;
+    dependees: string[] | any; // Array of ids for documents that refers to this document in template
     rendered?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     published?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     updated: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;

--- a/functions/src/models/document.models.ts
+++ b/functions/src/models/document.models.ts
@@ -11,6 +11,8 @@ export interface Document {
     status: DocumentStatus;
     tags: string[];
     standalone: boolean;
+    timesRendered: number | any; // firebase.firestore.FieldValue.increment;
+    rendered?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     published?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     updated: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     created: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;

--- a/functions/src/models/document.models.ts
+++ b/functions/src/models/document.models.ts
@@ -11,7 +11,7 @@ export interface Document {
     status: DocumentStatus;
     tags: string[];
     standalone: boolean;
-    dependees: string[] | any; // Array of ids for documents that refers to this document in template
+    dependencies: string[] | any; // Array of ids for documents that are referred to by this document
     rendered?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     published?: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;
     updated: any; // firebase.firestore.Timestamp | firebase.firestore.FieldValue.serverTimestamp;

--- a/functions/src/models/index.ts
+++ b/functions/src/models/index.ts
@@ -1,5 +1,4 @@
 export * from './app-config.models';
-export * from './cache.models';
 export * from './document.models';
 export * from './document-type.models';
 export * from './dynamic-page.models';

--- a/functions/src/services/document.service.ts
+++ b/functions/src/services/document.service.ts
@@ -51,6 +51,6 @@ export async function getDocumentByUrl(url: string): Promise<Document[]> {
 export async function addDependency(docId: string, references: string | string[]) {
     console.log(`[addDependency] ${JSON.stringify({ docId, references })}`);
     return siteCollection().collection('documents').doc(docId).update({
-        dependees: admin.firestore.FieldValue.arrayUnion(references),
+        dependencies: admin.firestore.FieldValue.arrayUnion(references),
     } as Document);
 }

--- a/functions/src/services/document.service.ts
+++ b/functions/src/services/document.service.ts
@@ -2,6 +2,7 @@ import * as admin from 'firebase-admin';
 import { Document } from '../models';
 
 const siteCollection = () => admin.firestore().collection('tanam').doc(process.env.GCLOUD_PROJECT);
+const siteRef = () => admin.database().ref('tanam').child(process.env.GCLOUD_PROJECT);
 const normalizeUrl = (url: string) => `/${url}`.replace(/\/+/g, '/');
 
 export async function getDocumentById(docId: string): Promise<Document> {
@@ -48,5 +49,8 @@ export async function getDocumentByUrl(url: string): Promise<Document[]> {
  * @param references One or more document IDs that are being referred to in a document
  */
 export async function addDependency(docId: string, references: string | string[]) {
-    const documentsCollection = siteCollection().collection('documents');
+    console.log(`[addDependency] ${JSON.stringify({ docId, references })}`);
+    return siteCollection().collection('documents').doc(docId).update({
+        dependees: admin.firestore.FieldValue.arrayUnion(references),
+    } as Document);
 }

--- a/functions/src/services/page-context.service.ts
+++ b/functions/src/services/page-context.service.ts
@@ -89,7 +89,10 @@ async function _toContext(document: Document) {
     // Run update operation in parallel while doing preparing the context data
     const updatePromise = siteCollection()
         .collection('documents').doc(document.id)
-        .update({ rendered: admin.firestore.FieldValue.serverTimestamp() } as Document);
+        .update({
+            dependencies: [],
+            rendered: admin.firestore.FieldValue.serverTimestamp(),
+        } as Document);
 
     const siteInfo = (await siteCollection().get()).data() as SiteInformation;
     const siteContext: SiteContext = {

--- a/functions/src/services/page-context.service.ts
+++ b/functions/src/services/page-context.service.ts
@@ -89,10 +89,7 @@ async function _toContext(document: Document) {
     // Run update operation in parallel while doing preparing the context data
     const updatePromise = siteCollection()
         .collection('documents').doc(document.id)
-        .update({
-            timesRendered: admin.firestore.FieldValue.increment(1),
-            rendered: admin.firestore.FieldValue.serverTimestamp(),
-        } as Document);
+        .update({ rendered: admin.firestore.FieldValue.serverTimestamp() } as Document);
 
     const siteInfo = (await siteCollection().get()).data() as SiteInformation;
     const siteContext: SiteContext = {

--- a/functions/src/services/task.service.ts
+++ b/functions/src/services/task.service.ts
@@ -1,0 +1,27 @@
+
+import * as admin from 'firebase-admin';
+import { CacheTask, CacheTaskAction } from '../models';
+
+const baseRef = (siteId) => admin.database().ref('tanam').child(siteId).child('tasks');
+const cacheQueueRef = (siteId) => baseRef(siteId).child('cache');
+
+
+async function makeCacheTask(siteId: string, domain: string, path: string, action: CacheTaskAction) {
+    const taskQueueRef = cacheQueueRef(siteId);
+
+    if (!path) {
+        return null;
+    }
+
+    const cacheTask = {
+        action: action,
+        domain: domain,
+        url: path,
+    } as CacheTask;
+
+    console.log(`[makeCacheTask] ${JSON.stringify(cacheTask)}`);
+    return taskQueueRef.push(cacheTask);
+}
+
+export const updateCache = (siteId: string, domain: string, path: string) => makeCacheTask(siteId, domain, path, 'update');
+export const deleteCache = (siteId: string, domain: string, path: string) => makeCacheTask(siteId, domain, path, 'delete');

--- a/functions/src/services/task.service.ts
+++ b/functions/src/services/task.service.ts
@@ -1,27 +1,17 @@
 
 import * as admin from 'firebase-admin';
-import { CacheTask, CacheTaskAction } from '../models';
 
-const baseRef = (siteId) => admin.database().ref('tanam').child(siteId).child('tasks');
-const cacheQueueRef = (siteId) => baseRef(siteId).child('cache');
+const taskQueueRef = (siteId) => admin.database().ref('tanam').child(siteId).child('tasks');
+const cacheQueueRef = (siteId) => taskQueueRef(siteId);
 
-
-async function makeCacheTask(siteId: string, domain: string, path: string, action: CacheTaskAction) {
-    const taskQueueRef = cacheQueueRef(siteId);
-
+async function makeCacheTask(siteId: string, path: string, action: 'create' | 'update' | 'delete') {
     if (!path) {
         return null;
     }
-
-    const cacheTask = {
-        action: action,
-        domain: domain,
-        url: path,
-    } as CacheTask;
-
-    console.log(`[makeCacheTask] ${JSON.stringify(cacheTask)}`);
-    return taskQueueRef.push(cacheTask);
+    console.log(`[makeCacheTask] ${JSON.stringify({ siteId, path, action })}`);
+    return cacheQueueRef(siteId).child('cache').child(action).push(path);
 }
 
-export const updateCache = (siteId: string, domain: string, path: string) => makeCacheTask(siteId, domain, path, 'update');
-export const deleteCache = (siteId: string, domain: string, path: string) => makeCacheTask(siteId, domain, path, 'delete');
+export const createCache = (siteId: string, path: string) => makeCacheTask(siteId, path, 'create');
+export const updateCache = (siteId: string, path: string) => makeCacheTask(siteId, path, 'update');
+export const deleteCache = (siteId: string, path: string) => makeCacheTask(siteId, path, 'delete');

--- a/functions/src/triggers/cache.ts
+++ b/functions/src/triggers/cache.ts
@@ -1,30 +1,7 @@
+import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import * as https from 'https';
-import { CacheTask } from '../models';
-
-export const cacheTask = functions.database.ref('tanam/{siteId}/tasks/cache/{taskId}').onCreate(async (snap) => {
-    const task = snap.val() as CacheTask;
-
-    const promises: Promise<any>[] = [snap.ref.remove()];
-
-    switch (task.action) {
-        case 'delete':
-            promises.push(makeRequest('PURGE', task.domain, task.url));
-            break;
-
-        case 'create':
-            promises.push(makeRequest('GET', task.domain, task.url));
-            break;
-
-        case 'update':
-        default:
-            await makeRequest('PURGE', task.domain, task.url);
-            promises.push(makeRequest('GET', task.domain, task.url));
-    }
-
-    return promises;
-});
-
+import { SiteInformation } from '../models';
 
 /**
  * Send a request to either purge or heat the CDN
@@ -42,7 +19,7 @@ export const cacheTask = functions.database.ref('tanam/{siteId}/tasks/cache/{tas
  * @param host Domain host (e.g. somesubdomain.example.com)
  * @param path Path part of the URL
  */
-function makeRequest(action: 'PURGE' | 'GET', host: string, path: string) {
+function _makeRequest(action: 'PURGE' | 'GET', host: string, path: string) {
     const normalizedPath = path.replace(/\/+/g, '/');
     const opts = {
         hostname: host,
@@ -54,8 +31,37 @@ function makeRequest(action: 'PURGE' | 'GET', host: string, path: string) {
     console.log(`[makeRequest] BEGIN ${JSON.stringify(opts)}`);
     return new Promise((resolve) => {
         https.get(opts, (res) => {
-            console.log(`[makeRequest] FINISHED ${JSON.stringify({...opts, statusCode: res.statusCode, statusMessage: res.statusMessage})}`);
+            console.log(`[makeRequest] FINISHED ${JSON.stringify({ ...opts, statusCode: res.statusCode, statusMessage: res.statusMessage })}`);
             resolve(null);
         });
     });
 }
+
+export const handleCacheTask = functions.database.ref('tanam/{siteId}/tasks/cache/{action}/{taskId}').onCreate(async (snap, context) => {
+    const siteId = context.params.siteId;
+    const action = context.params.action;
+    const url = snap.val() as string;
+    console.log(`${JSON.stringify({ action, url })}`);
+
+    const promises: Promise<any>[] = [snap.ref.remove()];
+
+    const siteInfoDoc = await admin.firestore().collection('tanam').doc(siteId).get();
+    const siteInfo = siteInfoDoc.data() as SiteInformation;
+
+    if (action === 'update') {
+        console.log(`Purge cache and wait for all to finish: ${JSON.stringify(siteInfo.domains)}`);
+        await Promise.all(siteInfo.domains.map(domain => _makeRequest('PURGE', domain, url)));
+    }
+
+    if (action === 'create' && action === 'update') {
+        console.log(`Create cache: ${JSON.stringify(siteInfo.domains)}`);
+        siteInfo.domains.forEach(domain => promises.push(_makeRequest('GET', domain, url)));
+    }
+
+    if (action === 'delete') {
+        console.log(`Purge cache: ${JSON.stringify(siteInfo.domains)}`);
+        siteInfo.domains.forEach(domain => promises.push(_makeRequest('PURGE', domain, url)));
+    }
+
+    return promises;
+});

--- a/functions/src/triggers/cache.ts
+++ b/functions/src/triggers/cache.ts
@@ -53,7 +53,7 @@ export const handleCacheTask = functions.database.ref('tanam/{siteId}/tasks/cach
         await Promise.all(siteInfo.domains.map(domain => _makeRequest('PURGE', domain, url)));
     }
 
-    if (action === 'create' && action === 'update') {
+    if (action === 'create' || action === 'update') {
         console.log(`Create cache: ${JSON.stringify(siteInfo.domains)}`);
         siteInfo.domains.forEach(domain => promises.push(_makeRequest('GET', domain, url)));
     }

--- a/functions/src/triggers/documents.ts
+++ b/functions/src/triggers/documents.ts
@@ -20,11 +20,6 @@ export const onDeleteDocumentCleanUp = functions.firestore.document('tanam/{site
     const documentId = context.params.documentId;
     const document = snap.data() as Document;
 
-    if (!document.standalone || document.status !== 'published') {
-        console.log(`The document is not published and standalone and is not managed by cache. Do nothing.`);
-        return null;
-    }
-
     const referencingDocs = await admin.firestore()
         .collection('tanam').doc(siteId)
         .collection('documents')
@@ -44,11 +39,6 @@ export const onUpdateRequestRendering = functions.firestore.document('tanam/{sit
     const documentId = context.params.documentId;
     const entryBefore = change.before.data() as Document;
     const entryAfter = change.after.data() as Document;
-
-    if (!entryBefore.standalone && !entryAfter.standalone) {
-        console.log(`The document is not standalone and is not managed by cache. Do nothing.`);
-        return null;
-    }
 
     if (['data', 'title', 'url', 'tags', 'standalone', 'status', 'published'].every(key =>
         JSON.stringify(entryBefore[key]) === JSON.stringify(entryAfter[key])

--- a/functions/src/triggers/documents.ts
+++ b/functions/src/triggers/documents.ts
@@ -34,7 +34,7 @@ export const onDeleteDocumentCleanUp = functions.firestore.document('tanam/{site
     return Promise.all(promises);
 });
 
-export const onUpdateRequestRendering = functions.firestore.document('tanam/{siteId}/documents/{documentId}').onUpdate(async (change, context) => {
+export const onUpdateDocumentRequestRendering = functions.firestore.document('tanam/{siteId}/documents/{documentId}').onUpdate(async (change, context) => {
     const siteId = context.params.siteId;
     const documentId = context.params.documentId;
     const entryBefore = change.before.data() as Document;
@@ -60,7 +60,9 @@ export const onUpdateRequestRendering = functions.firestore.document('tanam/{sit
     promises.push(taskService.updateCache(siteId, entryAfter.url));
 
     for (const doc of referencingDocs.docs) {
-        promises.push(taskService.updateCache(siteId, doc.data().url));
+        const referringDocument = doc.data() as Document;
+        console.log(`Referenced by document id=${referringDocument.id}, url=${referringDocument.url}`);
+        promises.push(taskService.updateCache(siteId, referringDocument.url));
     }
 
     return Promise.all(promises);

--- a/functions/src/triggers/documents.ts
+++ b/functions/src/triggers/documents.ts
@@ -47,7 +47,7 @@ export const onUpdateRequestRendering = functions.firestore.document('tanam/{sit
         return null;
     }
 
-    await change.after.ref.update({ dependencies: [] } as Document);
+    console.log(JSON.stringify({ siteId, documentId, urlBefore: entryBefore.url, urlAfter: entryAfter.url }));
     const referencingDocs = await admin.firestore()
         .collection('tanam').doc(siteId)
         .collection('documents')

--- a/functions/src/triggers/documents.ts
+++ b/functions/src/triggers/documents.ts
@@ -20,14 +20,9 @@ export const onChangeRequestRendering = functions.firestore.document('tanam/{sit
         return null;
     }
 
-    const siteInfoDoc = await admin.firestore().collection('tanam').doc(siteId).get();
-    const siteInfo = siteInfoDoc.data() as SiteInformation;
-
     const promises = [];
-    siteInfo.domains.forEach(domain => {
-        promises.push(taskService.updateCache(siteId, domain, entryBefore.url));
-        promises.push(taskService.updateCache(siteId, domain, entryAfter.url));
-    });
+    promises.push(taskService.updateCache(siteId, entryBefore.url));
+    promises.push(taskService.updateCache(siteId, entryAfter.url));
 
     return Promise.all(promises);
 });


### PR DESCRIPTION
This implements registration and usage of a dependency graph for cache management. 

 1. Document change
 2. Trigger cache refresh
 3. Check for all documents that fulfills:
   a. Include this document id in its `dependencies`
   b. Document was rendered **before** this document was updated
 4. Request cache refresh for all dependees

This algorithm works in parallel and asynchronous since it will reach consensus once all documents that are depending on the previous document has been re-rendered with newer timestamps than the `updated` timestamp.